### PR TITLE
Check if response header has int value

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -249,6 +249,9 @@
               if (vs.join) {
                 vs = vs.join("\n");
               }
+              if (typeof(vs) == 'number') {
+                vs = vs + '';
+              }
               v = vs.split("\n");
               this.headers[k] = v.length > 1 ? v : vs;
             }


### PR DESCRIPTION
I started getting the same error as in this issue, https://github.com/basecamp/pow/issues/32, and figured we could guard against trying to split() an integer. If someone knows a better way than this hack then go for it!