### PR TITLE
Fix Ruby nested exception EOFError

### DIFF
--- a/lib/nack/server.rb
+++ b/lib/nack/server.rb
@@ -103,9 +103,13 @@ module Nack
           else
             client, buf = sock, buffers[sock] ||= ''
 
+            buf_complete = false
             begin
               buf << client.read_nonblock(1024)
             rescue EOFError
+              buf_complete = true
+            end
+            if buf_complete
               handle sock, StringIO.new(buf)
               buffers.delete(client)
               clients.delete(client)

--- a/test/fixtures/error_cause.ru
+++ b/test/fixtures/error_cause.ru
@@ -1,0 +1,8 @@
+run lambda { |env|
+  begin
+    raise "b00m"
+  rescue => e
+    # If there is a `cause`, raise it instead of the "b00m" exception that we are expecting.
+    raise e.cause || e
+  end
+}

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -157,7 +157,7 @@ class TestNackWorker < Minitest::Test
   end
 
   ##
-  # Ensure that the server is not pulluting the Ruby exception nesting stack.
+  # Ensure that the server is not pulluting Ruby exception nesting.
   # There should be no `cause` placed in this stack by our Rack server.
   def test_app_error_cause_not_polluted
     start :error_cause do

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -102,7 +102,6 @@ class TestNackWorker < Minitest::Test
       assert error
 
       assert_equal "JSON::ParserError", error['name']
-      assert_equal "A JSON text must at least contain two octets!", error['message']
     end
   end
 


### PR DESCRIPTION
Ruby somewhat recently (2.1) added support for nested exceptions. If any code run within a `rescue` block raises an exception, Ruby will store the rescued exception in the newly-created exception as its `cause`.

Nack causes a problem with this by reading the incoming request buffer until an `EOFError` is raised, then calling `handle`, which runs the request, _within the rescue block_. This causes any exception raised in the Rack app to have a `cause` of `EOFError`.

The fix for this is actually pretty simple: set a flag when the `EOFError` is raised. Check for the flag once outside of the `rescue`, and `handle` the request.

I also added a test that covers this, which was failing before the change to `server.rb` was applied.

---

This issue has rarely been visible, but it is the cause of https://github.com/charliesome/better_errors/issues/44

[This change](https://github.com/charliesome/better_errors/pull/354) in better_errors causes the issue to permanently break better_errors when running in a nack server (Pow for example) because it started looking at the exception `cause` for the first time. This PR was merged almost a year ago, and then the project went quiet and has not made a release that includes the PR.

So to see this issue, you must be:

1. Running Ruby 2.1 or higher
2. Using Pow
3. Using better_errors 2.2.0 or higher.